### PR TITLE
Class Bbsnly\\ChartJs\\ChartServiceProvider removed but used in composer.json as laravel provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,6 @@
             "Tests\\": "tests/"
         }
     },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Bbsnly\\ChartJs\\ChartServiceProvider"
-            ]
-        }
-    },
     "require-dev": {
         "phpunit/phpunit": "^9.2"
     },


### PR DESCRIPTION
Version 3.x ist currently not installable with laravel package discovery

Fixes #5